### PR TITLE
Update Ruby version and fastlane command in CI workflow

### DIFF
--- a/.github/workflows/android_fastlane_firebase_app_distribution.yaml
+++ b/.github/workflows/android_fastlane_firebase_app_distribution.yaml
@@ -44,7 +44,7 @@ jobs:
     - name: Setup Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '3.4.4'
+        ruby-version: '3.2'
         bundler-cache: true
         # working-directory: android
 
@@ -80,5 +80,5 @@ jobs:
         FIREBASE_CLI_TOKEN: ${{ secrets.FIREBASE_CLI_TOKEN }}
         VERSION_BUMP_STRATEGY: ${{ steps.version_strategy.outputs.strategy }}
       run: |
-        bundle exec fastlane android firebase_distribution
+        fastlane android firebase_distribution
       working-directory: android


### PR DESCRIPTION
Changed the Ruby version from 3.4.4 to 3.2 and removed 'bundle exec' from the fastlane command in the Android Firebase App Distribution GitHub Actions workflow.