### PR TITLE
Update release notes in Fastfile test lane

### DIFF
--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -12,7 +12,7 @@ platform :android do
             android_artifact_type: "APK",
             apk_path: "../build/app/outputs/flutter-apk/app-production-release.apk",
             testers: "softagi.tech@gmail.com",
-            release_notes: "Test Lane"
+            release_notes: "Test Lane with github actions",
         )
   end
 end


### PR DESCRIPTION
Changed the release notes for the test lane to 'Test Lane with github actions' to reflect integration with GitHub Actions.